### PR TITLE
new block listen thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,18 @@
 # solominer
 Solo Mining in python for BTC Block Reward, Pure luck
 
-10 Million nonce is checked to see if you could accidently solve the mining problem in 1 thread using Python and Get BTC Block Reward. 
+This is a solominer random nonences between 0-4294967295 are checked to see if you could accidently solve the mining problem in 1 thread using Python and Get BTC Block Reward, this miner requests job from solockpool and start hashing the block header using random noncences, while a new block is detected on network, the miner restarts automatically in order to request new job from ckpool. 
+
 It is based on Luck giving so much hashrate all around the world, but still possible.
 
-The Script will display those hash having more than 5 zeros in the beginning. Although the current difficulty for getting mining reward is 17 zeros. 
+The Script will display those hash having more than 7 zeros in the beginning. Although the current difficulty for getting mining reward is 17 zeros. All events is stored in a file called miner.log. 
 Good Luck !!
 
+You should replace the existing bitcoin adress in solo_miner.py with your own bitcoin address.
+
 ```
-(base) C:\anaconda3>python solo_miner.py
-address:1Q1Ten9ASaVMswFmvu64spJi96SojHCNWv nonce:d8a5f0ce
-host:solo.ckpool.org port:3333
-[{'id': None,
-  'method': 'mining.notify',
-  'params': ['5eebeafb00056bf1',
-             '2341b4b45130c2dcd71b5125669a4b420aed971a0000a0450000000000000000',
-             '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff35038c2c0a000441f60660041cb29a230c',
-             '0a636b706f6f6c112f736f6c6f2e636b706f6f6c2e6f72672fffffffff0348585f2b000000001976a914fc6123f4bfd3a840b4387ab90e9801e98fb17cf888ac4f99e200000000001976a914f4cbe6c6bb3a8535c963169c22963d3a20e7686988ac0000000000000000266a24aa21a9edd00699d3cfb933ea6f2c37af71445ea2f9f629357d20431df2257351a16d6c3100000000',
-             ['66422ab9aeec34851fe5f6af7c67742964ea0aa24a1bc2569c0c5352ac4584fa',
-              'df36b9cd750b7880a62a1a6137b5d1491d1a65c7dc8dd12e152a31fe9078e527',
-              '241f33dd7641db547a7103d011a89a45de980fcd8a11a3ec01c27cc6a644921c',
-              '86b60edfe924c90d555cbd49c1d89c1f4f6c6e21f4689d8ababcbbba597a7309',
-              '55ef7f1e9c823f92990138c7f20153d65131068d1579bad2debbdf8fa2b3351e',
-              'f753abddf47afb7fd18acf21d8e87905a793042028a8a7e0b9da5c784fc263a9',
-              '44252d2c07fc54cddc59ea774829c1607c8f6cad34cbea9e7eaa1d8c5789c3d7',
-              'eb4ebfe3a4529a5e867a3dfa4fbdaec7e8740afea609514e042226900af84603',
-              '8802b964474a87ead205b50bf02cb039f378dc889b0cebe931a6db2ff32dee2d',
-              '9bef95a1e028a485bf2aeb2a9cb6ed3b89a30292961577aabea2725f45abb4bf',
-              '31b9eb9cfd4ff874f91bce8136d0193015b08ab30813b344a8f06da9e05e037e',
-              'cef0a89bebe65e3b1785a2395cd895943af99f1945e25df09c41410bbcaf16d1'],
-             '20000000',
-             '170da8a1',
-             '6006f641',
-             True]}]
-nbits:170da8a1 target:0000000000000000000da8a10000000000000000000000000000000000000000
+python solo_miner.py
+[*] Bitcoin Miner Started
 
-coinbase:
-01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff35038c2c0a000441f60660041cb29a230cc251c062000000005a9530680a636b706f6f6c112f736f6c6f2e636b706f6f6c2e6f72672fffffffff0348585f2b000000001976a914fc6123f4bfd3a840b4387ab90e9801e98fb17cf888ac4f99e200000000001976a914f4cbe6c6bb3a8535c963169c22963d3a20e7686988ac0000000000000000266a24aa21a9edd00699d3cfb933ea6f2c37af71445ea2f9f629357d20431df2257351a16d6c3100000000
-
-coinbase hash:b'5261ef9773b69709288cf06e7b6268f3894f5a58581a81c2eeb41555052c3269'
-
-merkle_root:48be309d2557405817da80363d8fa7678a414ee57cbb2f29e6cc007d687b8db1
-
-hash: 00000e852db967a42a38ef23e2ca9ae786bb479670b7351d8f7763f9281fb343
-hash: 00000ab2a4378beb85434b2f52b4f1e962081b5b99400d504460aa3d15149c45
-hash: 00000ee49f8a7b73cfc7dd7a4dcc7d68f17e491f38296782b83f0cb98132e7b9
-hash: 000001ddd5858c18523c9dead49f5bef2ed7e697a1bb86bb28159d85fb7db131
-hash: 0000002bd08474b821894004d439845e6b2c9b090375026b667c1adb264738cf
-hash: 00000d0f9a4c8fde790398ffa648ec99fc25bf9519748e7c42ba0a7215b7ee0e
-hash: 000006b3079216c7cd5866858f7eccd7eb6186a3a71428072661e558b752c9df
-Finished 10M Search. You can re-attempt to try your luck for solo reward !!
 ```
+You can run it local on your pc or in aws instance, if you run it on aws for example you can setup a cronjob to run every 2-3 minutes in any case that miner stops to restart the miner. Good luck.

--- a/README.md
+++ b/README.md
@@ -5,14 +5,24 @@ This is a solominer random nonences between 0-4294967295 are checked to see if y
 
 It is based on Luck giving so much hashrate all around the world, but still possible.
 
-The Script will display those hash having more than 7 zeros in the beginning. Although the current difficulty for getting mining reward is 17 zeros. All events is stored in a file called miner.log. 
-Good Luck !!
+The Script will store in miner.log file those hashes having more than 7 zeros in the beginning. Although the current difficulty for getting mining reward is 19 zeros. All events is stored in a file called miner.log. 
 
-You should replace the existing bitcoin adress in solo_miner.py with your own bitcoin address.
+### You should replace the existing bitcoin adress in solo_miner.py with your own bitcoin address.
 
+
+
+
+For local run in your pc 
 ```
-python solo_miner.py
+python3 solo_miner.py
 [*] Bitcoin Miner Started
 
 ```
+If you want to run it aws instance or vps server 
+```
+nohup python3 solo_miner.py &
+
+```
+
+
 You can run it local on your pc or in aws instance, if you run it on aws for example you can setup a cronjob to run every 2-3 minutes in any case that miner stops to restart the miner. Good luck.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # solominer
 Solo Mining in python for BTC Block Reward, Pure luck
 
-This is a solominer random nonences between 0-4294967295 are checked to see if you could accidently solve the mining problem in 1 thread using Python and Get BTC Block Reward, this miner requests job from solockpool and start hashing the block header using random noncences, while a new block is detected on network, the miner restarts automatically in order to request new job from ckpool. 
+This is a solominer random nonences between 0-4294967295 are checked to see if you could accidently solve the mining problem using Python and Get BTC Block Reward, this miner requests job from solockpool and start hashing the block header using random noncences, while a new block is detected on network, the miner restarts automatically in order to request new job from ckpool, if a nonce is found the blockheader data is submited to ckpool  automatically. 
 
 It is based on Luck giving so much hashrate all around the world, but still possible.
 

--- a/solo_miner.py
+++ b/solo_miner.py
@@ -4,94 +4,156 @@
 @author: iceland
 """
 
-import socket
-import json
-import hashlib
-import binascii
+
 from pprint import pprint
-import time
+from threading import Thread
+import requests
+import binascii
+import hashlib
+import logging
+import socket
 import random
+import json
+import time
 
+
+cHeight = 0 
+
+
+# replace it with your bitcoin address
 address = '1Q1Ten9ASaVMswFmvu64spJi96SojHCNWv'
-nonce   = hex(random.randint(0,2**32-1))[2:].zfill(8)
-
-host    = 'solo.ckpool.org'
-port    = 3333
-#host    = 'pool.mainnet.bitcoin-global.io'
-#port    = 9223
-
-print("address:{} nonce:{}".format(address,nonce))
-print("host:{} port:{}".format(host,port))
-
-sock    = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-sock.connect((host,port))
-
-#server connection
-sock.sendall(b'{"id": 1, "method": "mining.subscribe", "params": []}\n')
-lines = sock.recv(1024).decode().split('\n')
-response = json.loads(lines[0])
-sub_details,extranonce1,extranonce2_size = response['result']
-
-#authorize workers
-sock.sendall(b'{"params": ["'+address.encode()+b'", "password"], "id": 2, "method": "mining.authorize"}\n')
-
-#we read until 'mining.notify' is reached
-response = b''
-while response.count(b'\n') < 4 and not(b'mining.notify' in response):
-    response += sock.recv(1024)
 
 
-#get rid of empty lines
-responses = [json.loads(res) for res in response.decode().split('\n') if len(res.strip())>0 and 'mining.notify' in res]
-pprint(responses)
 
-job_id,prevhash,coinb1,coinb2,merkle_branch,version,nbits,ntime,clean_jobs \
-    = responses[0]['params']
 
-target = (nbits[2:]+'00'*(int(nbits[:2],16) - 3)).zfill(64)
-print('nbits:{} target:{}\n'.format(nbits,target))
+def logg(msg):
+    logging.basicConfig(level=logging.INFO, filename="miner.log", format='%(asctime)s %(message)s') # include timestamp
+    logging.info(msg)
 
-# extranonce2 = '00'*extranonce2_size
-extranonce2 = hex(random.randint(0,2**32-1))[2:].zfill(2*extranonce2_size)      # create random
 
-coinbase = coinb1 + extranonce1 + extranonce2 + coinb2
-coinbase_hash_bin = hashlib.sha256(hashlib.sha256(binascii.unhexlify(coinbase)).digest()).digest()
 
-print('coinbase:\n{}\n\ncoinbase hash:{}\n'.format(coinbase,binascii.hexlify(coinbase_hash_bin)))
-merkle_root = coinbase_hash_bin
-for h in merkle_branch:
-    merkle_root = hashlib.sha256(hashlib.sha256(merkle_root + binascii.unhexlify(h)).digest()).digest()
 
-merkle_root = binascii.hexlify(merkle_root).decode()
+def get_current_block_height():
+    # Returns the current network best height 
+    r = requests.get('https://blockchain.info/latestblock')
+    return int(r.json()['height'])
 
-#little endian
-merkle_root = ''.join([merkle_root[i]+merkle_root[i+1] for i in range(0,len(merkle_root),2)][::-1])
 
-print('merkle_root:{}\n'.format(merkle_root))
 
-def noncework():
-    nonce   = hex(random.randint(0,2**32-1))[2:].zfill(8)   #hex(int(nonce,16)+1)[2:]
-    blockheader = version + prevhash + merkle_root + nbits + ntime + nonce +\
+def newBlockListener():
+
+    global cHeight
+
+    while True:
+        network_height = get_current_block_height()
+
+        if network_height > cHeight: 
+            logg('[*] Network has new height %d ' %network_height)
+            logg('[*] Our local is %d' %cHeight)
+            cHeight = network_height
+            logg('[*] Our new local after update is %d' %cHeight)
+
+        # respect Api
+        time.sleep(40)
+
+
+
+
+
+def BitcoinMiner(restart=False):
+
+    if restart:
+        time.sleep(2)
+        logg('[*] Bitcoin Miner Restarted')
+    else:
+        logg('[*] Bitcoin Miner Started')
+        print('[*] Bitcoin Miner Started')
+
+
+
+    sock    = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect(('solo.ckpool.org', 3333))
+
+    sock.sendall(b'{"id": 1, "method": "mining.subscribe", "params": []}\n')
+
+
+    lines = sock.recv(1024).decode().split('\n')
+
+    response = json.loads(lines[0])
+    sub_details,extranonce1,extranonce2_size = response['result']
+
+    sock.sendall(b'{"params": ["'+address.encode()+b'", "password"], "id": 2, "method": "mining.authorize"}\n')
+
+    response = b''
+    while response.count(b'\n') < 4 and not(b'mining.notify' in response): response += sock.recv(1024)
+
+    responses = [json.loads(res) for res in response.decode().split('\n') if len(res.strip())>0 and 'mining.notify' in res]
+    job_id,prevhash,coinb1,coinb2,merkle_branch,version,nbits,ntime,clean_jobs = responses[0]['params']
+    target = (nbits[2:]+'00'*(int(nbits[:2],16) - 3)).zfill(64)
+    extranonce2 = hex(random.randint(0,2**32-1))[2:].zfill(2*extranonce2_size)      # create random
+
+    coinbase = coinb1 + extranonce1 + extranonce2 + coinb2
+    coinbase_hash_bin = hashlib.sha256(hashlib.sha256(binascii.unhexlify(coinbase)).digest()).digest()
+
+    merkle_root = coinbase_hash_bin
+    for h in merkle_branch:
+        merkle_root = hashlib.sha256(hashlib.sha256(merkle_root + binascii.unhexlify(h)).digest()).digest()
+
+    merkle_root = binascii.hexlify(merkle_root).decode()
+
+    #little endian
+    merkle_root = ''.join([merkle_root[i]+merkle_root[i+1] for i in range(0,len(merkle_root),2)][::-1])
+
+    
+
+    work_on = get_current_block_height()
+
+
+
+
+
+
+    while True:
+        if cHeight > work_on:
+            logg('[*] Restarting Miner')
+            BitcoinMiner(restart=True)
+            break 
+
+
+        nonce   = hex(random.randint(0,2**32-1))[2:].zfill(8) # nnonve   #hex(int(nonce,16)+1)[2:]
+        blockheader = version + prevhash + merkle_root + nbits + ntime + nonce +\
         '000000800000000000000000000000000000000000000000000000000000000000000000000000000000000080020000'
-    
-#    print('blockheader:\n{}\n'.format(blockheader))
-    
-    hash = hashlib.sha256(hashlib.sha256(binascii.unhexlify(blockheader)).digest()).digest()
-    hash = binascii.hexlify(hash).decode()
-#    print('hash: {}'.format(hash))
-    if(hash[:5] == '00000'): print('hash: {}'.format(hash))
-    if hash < target :
-#    if(hash[:10] == '0000000000'):
-        print('success!!')
-        print('hash: {}'.format(hash))
-        payload = bytes('{"params": ["'+address+'", "'+job_id+'", "'+extranonce2 \
-            +'", "'+ntime+'", "'+nonce+'"], "id": 1, "method": "mining.submit"}\n', 'utf-8')
-        sock.sendall(payload)
-        print(sock.recv(1024))
-#    else:
-#        print('failed mine, hash is greater than target')
+        hash = hashlib.sha256(hashlib.sha256(binascii.unhexlify(blockheader)).digest()).digest()
+        hash = binascii.hexlify(hash).decode()
 
-for k in range(10000000):
-    noncework()
-print("Finished 10M Search. You can re-attempt to try your luck for solo reward !!")
-sock.close()
+
+
+        if hash.startswith('000000000000000000000'): logg('hash: {}'.format(hash))
+        if hash.startswith('000000000000000000'): logg('hash: {}'.format(hash))
+        if hash.startswith('000000000000000'): logg('hash: {}'.format(hash))
+        if hash.startswith('000000000000'): logg('hash: {}'.format(hash))
+        if hash.startswith('0000000'): logg('hash: {}'.format(hash))
+
+
+
+        if hash >= target :
+            print('[*] New block mined')
+            logg('[*] success!!')
+            logg(blockheader)
+            logg('hash: {}'.format(hash))
+            payload = bytes('{"params": ["'+address+'", "'+job_id+'", "'+extranonce2 \
+                +'", "'+ntime+'", "'+nonce+'"], "id": 1, "method": "mining.submit"}\n', 'utf-8')
+            sock.sendall(payload)
+            logg(payload)
+            ret = sock.recv(1024)
+            logg(ret)
+
+            return True
+
+
+
+
+if __name__ == '__main__':
+    Thread(target = newBlockListener).start()
+    time.sleep(2)
+    Thread(target = BitcoinMiner).start()

--- a/solo_miner.py
+++ b/solo_miner.py
@@ -136,7 +136,7 @@ def BitcoinMiner(restart=False):
 
 
 
-        if hash >= target :
+        if hash < target :
             print('[*] New block mined')
             logg('[*] success!!')
             logg(blockheader)


### PR DESCRIPTION

As we know a block header is hashed repeatedly by miners by altering the nonce value, the blockheader contains the previous block hash, so i've add  poor new block listen thread that checks for new block in network, if a new block is detected, the miner stops to hash the current block header and starts working into a new block header, also i add a logging method that stores events into a file called miner.log instead of printing them in terminal. 
The pull request is just for reference.